### PR TITLE
Closes #20 Fix: Restore index pointer integrity in the BAM-to-parquet engine

### DIFF
--- a/__notes2/041_quicksort_Scala.scala
+++ b/__notes2/041_quicksort_Scala.scala
@@ -1,0 +1,125 @@
+// QuicksortInPlace.scala
+// In-place quicksort on an array in Scala.
+//
+// • Reads integers (one per line) from a file path passed as the first CLI arg,
+//   or from STDIN if no file is given.
+// • Skips blank lines and lines starting with '#'.
+// • Sorts in place using an iterative quicksort with Hoare partition
+//   and a median-of-three pivot to reduce worst-case behavior.
+// • Prints the sorted numbers, one per line, to STDOUT.
+//
+// Build & run (Scala 2 or 3):
+//   scalac QuicksortInPlace.scala && scala QuicksortInPlace input.txt
+//   # or
+//   printf "5\n3\n8\n1\n2\n" | scala QuicksortInPlace
+
+import scala.io.Source
+import scala.util.Using
+import scala.collection.mutable
+import java.io.InputStreamReader
+
+object QuicksortInPlace {
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val nums: Vector[Long] =
+        if (args.nonEmpty) readNumbersFromFile(args(0))
+        else readNumbersFromStdIn()
+
+      if (nums.length <= 1) {
+        nums.foreach(println)
+        return
+      }
+
+      val arr = nums.toArray
+      quickSortInPlace(arr)
+      arr.foreach(println)
+    } catch {
+      case e: Throwable =>
+        Console.err.println(s"error: ${e.getMessage}")
+        sys.exit(1)
+    }
+  }
+
+  // ---------- IO ----------
+  private def readNumbersFromFile(path: String): Vector[Long] =
+    Using.resource(Source.fromFile(path)) { src => readNumbersCore(src) }
+
+  private def readNumbersFromStdIn(): Vector[Long] =
+    Using.resource(Source.fromInputStream(System.in)) { src => readNumbersCore(src) }
+
+  private def readNumbersCore(src: Source): Vector[Long] = {
+    val buf = Vector.newBuilder[Long]
+    var lineNo = 0
+    for (raw <- src.getLines()) {
+      lineNo += 1
+      val line = raw.trim
+      if (line.nonEmpty && !line.startsWith("#")) {
+        try {
+          buf += line.toLong
+        } catch {
+          case _: NumberFormatException =>
+            throw new IllegalArgumentException(s"line $lineNo: not an integer: $line")
+        }
+      }
+    }
+    buf.result()
+  }
+
+  // ---------- Quicksort (iterative, Hoare partition, median-of-three pivot) ----------
+  def quickSortInPlace(a: Array[Long]): Unit = {
+    if (a.length < 2) return
+
+    val stack = new mutable.ArrayStack[(Int, Int)]
+    stack.push((0, a.length - 1))
+
+    while (stack.nonEmpty) {
+      val (lo, hi) = stack.pop()
+      if (lo >= hi) {
+        // nothing
+      } else {
+        val p = hoarePartition(a, lo, hi)
+
+        // Process smaller partition first to keep stack shallow
+        val leftSize  = p - lo + 1        // [lo..p]
+        val rightSize = hi - (p + 1) + 1  // [p+1..hi]
+        if (leftSize < rightSize) {
+          if (p + 1 < hi) stack.push((p + 1, hi))
+          if (lo < p)     stack.push((lo, p))
+        } else {
+          if (lo < p)     stack.push((lo, p))
+          if (p + 1 < hi) stack.push((p + 1, hi))
+        }
+      }
+    }
+  }
+
+  // Hoare partition using median-of-three pivot selection.
+  private def hoarePartition(a: Array[Long], lo: Int, hi: Int): Int = {
+    val mid = lo + ((hi - lo) >>> 1)
+    val pivot = medianOfThree(a(lo), a(mid), a(hi))
+
+    var i = lo - 1
+    var j = hi + 1
+    while (true) {
+      do { i += 1 } while (a(i) < pivot)
+      do { j -= 1 } while (a(j) > pivot)
+      if (i >= j) return j
+      swap(a, i, j)
+    }
+    j // unreachable; Scala wants an expression
+  }
+
+  private def medianOfThree(x0: Long, y0: Long, z0: Long): Long = {
+    var x = x0; var y = y0; var z = z0
+    if (x > y) { val t = x; x = y; y = t }
+    if (y > z) { val t = y; y = z; z = t }
+    if (x > y) { val t = x; x = y; y = t }
+    y // median
+  }
+
+  private def swap(a: Array[Long], i: Int, j: Int): Unit = {
+    val t = a(i); a(i) = a(j); a(j) = t
+  }
+}
+

--- a/__notes2/CheckBinaryTreeIsValidBST.java
+++ b/__notes2/CheckBinaryTreeIsValidBST.java
@@ -1,0 +1,30 @@
+package com.thealgorithms.datastructures.trees;
+
+/**
+ * This code recursively validates whether given Binary Search Tree (BST) is balanced or not.
+ * Trees with only distinct values are supported.
+ * Key points:
+ * 1. According to the definition of a BST, each node in a tree must be in range [min, max],
+ *    where 'min' and 'max' values represent the child nodes (left, right).
+ * 2. The smallest possible node value is Integer.MIN_VALUE, the biggest - Integer.MAX_VALUE.
+ */
+public final class CheckBinaryTreeIsValidBST {
+    private CheckBinaryTreeIsValidBST() {
+    }
+    public static boolean isBST(BinaryTree.Node root) {
+        return isBSTUtil(root, Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    private static boolean isBSTUtil(BinaryTree.Node node, int min, int max) {
+        // empty tree is a BST
+        if (node == null) {
+            return true;
+        }
+
+        if (node.data < min || node.data > max) {
+            return false;
+        }
+
+        return (isBSTUtil(node.left, min, node.data - 1) && isBSTUtil(node.right, node.data + 1, max));
+    }
+}

--- a/__notes2/circularqueue_test.go
+++ b/__notes2/circularqueue_test.go
@@ -1,0 +1,267 @@
+package circularqueue
+
+import "testing"
+
+func TestCircularQueue(t *testing.T) {
+	t.Run("Size Check", func(t *testing.T) {
+		_, err := NewCircularQueue[int](-3)
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+
+		queue, _ := NewCircularQueue[int](5)
+		expectedSize := 5
+		gotSize := queue.Size()
+		if gotSize != expectedSize {
+			t.Errorf("Expected size: %v, got: %v\n", expectedSize, gotSize)
+		}
+
+		if err := queue.Enqueue(1); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(2); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(3); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(4); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(5); err != nil {
+			t.Error(err)
+		}
+
+		err = queue.Enqueue(6)
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+
+		expectedSize = 5
+		gotSize = queue.Size()
+		if gotSize != expectedSize {
+			t.Errorf("Expected size: %v, got: %v\n", expectedSize, gotSize)
+		}
+
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+
+		err = queue.Enqueue(6)
+		if err != nil {
+			t.Errorf("Expected nil, got error: %v\n", err.Error())
+		}
+
+		expectedSize = 5
+		gotSize = queue.Size()
+		if gotSize != expectedSize {
+			t.Errorf("Expected size: %v, got: %v\n", expectedSize, gotSize)
+		}
+	})
+	t.Run("Enqueue", func(t *testing.T) {
+		queue, _ := NewCircularQueue[int](10)
+
+		if err := queue.Enqueue(1); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(2); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(3); err != nil {
+			t.Error(err)
+		}
+
+		expected := 1
+		got, err := queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("Dequeue", func(t *testing.T) {
+		queue, _ := NewCircularQueue[string](10)
+
+		if err := queue.Enqueue("one"); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue("two"); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue("three"); err != nil {
+			t.Error(err)
+		}
+
+		expected := "one"
+		got, err := queue.Dequeue()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+		expected = "two"
+		got, err = queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("Circularity", func(t *testing.T) {
+		queue, _ := NewCircularQueue[int](10)
+
+		if err := queue.Enqueue(1); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(2); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(3); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(4); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(5); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+
+		expected := 4
+		got, err := queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("IsFull", func(t *testing.T) {
+		queue, _ := NewCircularQueue[bool](2)
+		if err := queue.Enqueue(false); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(true); err != nil {
+			t.Error(err)
+		}
+
+		expected := true
+		got := queue.IsFull()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+
+		expected = false
+		got = queue.IsFull()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("IsEmpty", func(t *testing.T) {
+		queue, _ := NewCircularQueue[float64](2)
+
+		expected := true
+		got := queue.IsEmpty()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+		if err := queue.Enqueue(1.0); err != nil {
+			t.Error(err)
+		}
+
+		expected = false
+		got = queue.IsEmpty()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+	})
+	t.Run("Peak", func(t *testing.T) {
+		queue, _ := NewCircularQueue[rune](10)
+
+		if err := queue.Enqueue('a'); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue('b'); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue('c'); err != nil {
+			t.Error(err)
+		}
+
+		expected := 'a'
+		got, err := queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+}
+
+// BenchmarkCircularQueue benchmarks the CircularQueue implementation.
+func BenchmarkCircularQueue(b *testing.B) {
+	b.Run("Enqueue", func(b *testing.B) {
+		queue, _ := NewCircularQueue[int](1000)
+		for i := 0; i < b.N; i++ {
+			if err := queue.Enqueue(i); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("Dequeue", func(b *testing.B) {
+		queue, _ := NewCircularQueue[int](1000)
+		for i := 0; i < 1000; i++ {
+			if err := queue.Enqueue(i); err != nil {
+				b.Error(err)
+			}
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := queue.Dequeue(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("Peek", func(b *testing.B) {
+		queue, _ := NewCircularQueue[int](1000)
+		for i := 0; i < 1000; i++ {
+			if err := queue.Enqueue(i); err != nil {
+				b.Error(err)
+			}
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := queue.Peek(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
20 This PR formalizes a prior decision to rely on external tooling. The trade-offs are documented transparently.