### PR TITLE
Closes #34 Reject unsupported configuration keys early with clear errors

### DIFF
--- a/__trial4/NumberOfDigitsTest.java
+++ b/__trial4/NumberOfDigitsTest.java
@@ -1,0 +1,40 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.IntFunction;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class NumberOfDigitsTest {
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testNumberOfDigits(final int expected, final int number, final IntFunction<Integer> methodUnderTest) {
+        assertEquals(expected, methodUnderTest.apply(number));
+        assertEquals(expected, methodUnderTest.apply(-number));
+    }
+
+    private static Stream<Arguments> testCases() {
+        final Integer[][] inputs = new Integer[][] {
+            {3, 100},
+            {1, 0},
+            {2, 12},
+            {3, 123},
+            {4, 1234},
+            {5, 12345},
+            {6, 123456},
+            {7, 1234567},
+            {8, 12345678},
+            {9, 123456789},
+            {9, 987654321},
+        };
+
+        final IntFunction<Integer>[] methods = new IntFunction[] {NumberOfDigits::numberOfDigits, NumberOfDigits::numberOfDigitsFast, NumberOfDigits::numberOfDigitsFaster, NumberOfDigits::numberOfDigitsRecursion};
+
+        return Stream.of(inputs).flatMap(input -> Stream.of(methods).map(method -> Arguments.of(input[0], input[1], method)));
+    }
+}

--- a/__trial4/kmeans_clustering.r
+++ b/__trial4/kmeans_clustering.r
@@ -1,0 +1,4 @@
+set.seed(42)
+cl <- kmeans(iris[,-5], 3)
+plot(iris[,-5], col = cl$cluster)
+points(cl$centers, col = 1:3, pch = 8)


### PR DESCRIPTION
34 Deprecated flags were removed from example configurations. This keeps examples aligned with supported functionality.