### PR TITLE
Closes #77 Chore: Archive experimental bias-correction module as won't fix

### DIFF
--- a/__netip7/080_levenstein_JavaScript.js
+++ b/__netip7/080_levenstein_JavaScript.js
@@ -1,0 +1,34 @@
+function levenshteinDistance(s1, s2) {
+  const m = s1.length;
+  const n = s2.length;
+
+  // Initialize DP table
+  const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  // Base cases
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  // Fill table
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,        // Deletion
+        dp[i][j - 1] + 1,        // Insertion
+        dp[i - 1][j - 1] + cost  // Substitution
+      );
+    }
+  }
+
+  return dp[m][n];
+}
+
+// Read input
+const fs = require("fs");
+const input = fs.readFileSync(0, "utf-8").trim().split("\n");
+const s1 = input[0].trim();
+const s2 = input[1].trim();
+
+console.log(levenshteinDistance(s1, s2));
+

--- a/__netip7/bellmanford.go
+++ b/__netip7/bellmanford.go
@@ -1,0 +1,51 @@
+// The Bellman–Ford algorithm is an algorithm that computes shortest paths from a
+// single source vertex to all of the other vertices in a weighted directed graph.
+// It is slower than Dijkstra but capable of handling negative edge weights.
+// https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
+// Implementation is based on the book 'Introduction to Algorithms' (CLRS)
+// time complexity: O(V*E) where V is the number of vertices and E is the number of edges in the graph
+// space complexity: O(V) where V is the number of vertices in the graph
+
+package graph
+
+import (
+	"errors"
+	"math"
+)
+
+func (g *Graph) BellmanFord(start, end int) (isReachable bool, distance int, err error) {
+	INF := math.Inf(1)
+	distances := make([]float64, g.vertices)
+
+	// Set all vertices to unreachable, initialize source
+	for i := 0; i < g.vertices; i++ {
+		distances[i] = INF
+	}
+	distances[start] = 0
+
+	// Making iterations equal to #vertices
+	for n := 0; n < g.vertices; n++ {
+
+		// Looping over all edges
+		for u, adjacents := range g.edges {
+			for v, weightUV := range adjacents {
+
+				// If new shorter distance is found, update distance value (relaxation step)
+				if newDistance := distances[u] + float64(weightUV); distances[v] > newDistance {
+					distances[v] = newDistance
+				}
+			}
+		}
+	}
+
+	// Check for negative weight cycle
+	for u, adjacents := range g.edges {
+		for v, weightUV := range adjacents {
+			if newDistance := distances[u] + float64(weightUV); distances[v] > newDistance {
+				return false, -1, errors.New("negative weight cycle present")
+			}
+		}
+	}
+
+	return distances[end] != INF, int(distances[end]), nil
+}


### PR DESCRIPTION
77 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.