### PR TITLE
Closes #79 Document data retention policy guidelines

### DIFF
--- a/__mods8/InsertionSortTest.kt
+++ b/__mods8/InsertionSortTest.kt
@@ -1,0 +1,31 @@
+package sort
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class InsertionSortTest {
+
+    @Test
+    fun testInsertionSort1() {
+        val array = arrayOf(4, 3, 2, 8, 1)
+        insertionSort(array)
+
+        assertArrayEquals(array, arrayOf(1, 2, 3, 4, 8))
+    }
+
+    @Test
+    fun testInsertionSort2() {
+        val array = arrayOf(-1, 2, 43, 3, 97, 1, 0)
+        insertionSort(array)
+
+        assertArrayEquals(array, arrayOf(-1, 0, 1, 2, 3, 43, 97))
+    }
+
+    @Test
+    fun testInsertionSort3() {
+        val array = arrayOf("A", "D", "E", "C", "B")
+        insertionSort(array)
+
+        assertArrayEquals(array, arrayOf("A", "B", "C", "D", "E"))
+    }
+}

--- a/__mods8/TrieNode.php
+++ b/__mods8/TrieNode.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed) in Pull Request #162 and #172
+ * https://github.com/TheAlgorithms/PHP/pull/162
+ * https://github.com/TheAlgorithms/PHP/pull/172
+ *
+ * Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request addressing bugs/corrections to this file.
+ * Thank you!
+ */
+
+namespace DataStructures\Trie;
+
+class TrieNode
+{
+    /** @var array<string, TrieNode> */
+    public array $children;
+    public bool $isEndOfWord;
+
+    public function __construct()
+    {
+        $this->children = [];  // Associative array where [ char => TrieNode ]
+        $this->isEndOfWord = false;
+    }
+
+    /**
+     * Add a child node for a character.
+     */
+    public function addChild(string $char): TrieNode
+    {
+        $char = $this->normalizeChar($char);
+        if (!isset($this->children[$char])) {
+            $this->children[$char] = new TrieNode();
+        }
+        return $this->children[$char];
+    }
+
+    /**
+     * Check if a character has a child node.
+     */
+    public function hasChild(string $char): bool
+    {
+        $char = $this->normalizeChar($char);
+        return isset($this->children[$char]);
+    }
+
+    /**
+     * Get the child node corresponding to a character.
+     */
+    public function getChild(string $char): ?TrieNode
+    {
+        $char = $this->normalizeChar($char);
+        return $this->children[$char] ?? null;
+    }
+
+    /**
+     * Normalize the character to lowercase.
+     */
+    private function normalizeChar(string $char): string
+    {
+        return strtolower($char);
+    }
+}


### PR DESCRIPTION
79 Added missing parameter descriptions to the codon-lookup dictionary docstrings to clarify the expected input types for rare-mutation scoring. This improves the IDE-based autocomplete experience for developers working on the sequence-parsing logic. No functional changes were made to the core code.